### PR TITLE
Improve README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,35 @@
 # clife
-game of life
-## running
-<pre>
-./configure.sh
-cd cmake-build-release
-make
+
+A simple implementation of Conway's Game of Life written in C++ using SDL2.
+
+## Features
+- Classic Game of Life simulation.
+- Minimal SDL2 graphics output.
+- Example screenshot included in `sample.png`.
+
+## Requirements
+- C++17 compiler
+- CMake 3.3 or later
+- Boost libraries
+- SDL2 development libraries
+
+## Building
+1. Run `./configure.sh` to install required packages (Ubuntu) and to generate the build directories.
+2. Build the release configuration:
+   ```bash
+   cd cmake-build-release
+   make
+   ```
+   The executable `clife` will be produced in this directory.
+
+## Running
+Launch the program after building:
+```bash
 ./clife
-</pre>
+```
+A window will open showing the simulation running.
+
+## License
+This project is distributed under the MIT License. See [LICENSE.md](LICENSE.md) for the full license text.
+
 ![sample.png](./sample.png?raw=true)


### PR DESCRIPTION
## Summary
- expand README with features, requirements, and build instructions

## Testing
- `cmake ..`
- `make -j$(nproc)` *(fails: vstd.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68808d8e24a48326a285c6e674485c6a