### PR TITLE
Add submodule setup step

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -13,6 +13,9 @@ sudo apt install build-essential cmake -y
 sudo apt install libboost-dev libboost-system-dev -y
 sudo apt install libsdl2-dev -y
 
+# Ensure submodules are initialized
+git submodule update --init --recursive
+
 mkdir -p cmake-build-debug
 mkdir -p cmake-build-release
 


### PR DESCRIPTION
## Summary
- make sure configure script initializes git submodules

## Testing
- `bash configure.sh` *(fails: apt and git are unable to access the network)*

------
https://chatgpt.com/codex/tasks/task_e_68808e1db6988326bee4260a042c9894