### PR TITLE
Add popular Life-like rule preset buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Linux/X11 implementation of Conway's Game of Life written in C++.
 - Toroidal Game of Life simulation, so patterns wrap around the map edges.
 - Packed simulation backend with optimized Conway fast paths plus generic Life-like `B/S` rule support on the 8-neighbor Moore neighborhood.
 - Linux-native X11/XShm presentation path with no SDL dependency.
-- Lightweight always-visible X11 rules panel for live Birth/Survival edits while the simulation keeps running.
+- Lightweight always-visible X11 rules panel for live Birth/Survival edits and one-click preset switches while the simulation keeps running.
 - Headless fixed-frame benchmark mode with deterministic sizing, density, seed, mode, thread, and backend controls.
 - Automated correctness checks that compare the optimized backends against a scalar reference implementation.
 - Example screenshot included in `sample.png`.
@@ -60,6 +60,7 @@ Use the rules panel on the right side of the window to edit Life-like rules whil
 - Inputs are normalized to sorted unique digits.
 - Click `Apply`, or press `Enter` while a field is focused, to queue the new rule.
 - Click `Reset To Default` to restore Conway `B3/S23`.
+- Use the preset buttons to jump directly to `HighLife`, `2x2`, `Day & Night`, `Morley`, or `Seeds`.
 - The current active rule is shown as `B.../S...` in the panel.
 
 Rule changes preserve the current board state and take effect on the next generation boundary, so the app does not need to restart to switch to rules such as `B36/S23` or `B2/S`.

--- a/clife.cpp
+++ b/clife.cpp
@@ -78,6 +78,7 @@ namespace {
     constexpr int kRulesPanelSectionGap = 10;
     constexpr int kRulesFieldHeight = 28;
     constexpr int kRulesButtonHeight = 30;
+    constexpr int kRulesPresetButtonGap = 8;
     constexpr std::array<std::uint8_t, 18> kNextState = {
             0, 0, 0, 1, 0, 0, 0, 0, 0,
             0, 0, 1, 1, 0, 0, 0, 0, 0,
@@ -94,6 +95,19 @@ namespace {
         Scalar,
         Avx2,
     };
+
+    struct RulePreset {
+        std::string_view label;
+        RuleSet rules;
+    };
+
+    constexpr std::array<RulePreset, 5> kPopularRulePresets = {{
+            {"HighLife", RuleSet::from_digit_strings("36", "23")},
+            {"2x2", RuleSet::from_digit_strings("36", "125")},
+            {"Day & Night", RuleSet::from_digit_strings("3678", "34678")},
+            {"Morley", RuleSet::from_digit_strings("368", "245")},
+            {"Seeds", RuleSet::from_digit_strings("2", "")},
+    }};
 
     struct RuntimeOptions {
         int width = 10'000;
@@ -1860,17 +1874,29 @@ namespace {
             return queue_rule_change(RuleSet::from_digit_strings(_birth_input, _survival_input));
         }
 
+        [[nodiscard]] bool apply_rule(RuleSet rules) {
+            const RuleSet normalized = rules.normalized();
+            _birth_input = normalized.birth_digits();
+            _survival_input = normalized.survive_digits();
+            return queue_rule_change(normalized);
+        }
+
         [[nodiscard]] bool reset_to_default_rules() {
-            const RuleSet defaults = RuleSet::conway();
-            _birth_input = defaults.birth_digits();
-            _survival_input = defaults.survive_digits();
-            return queue_rule_change(defaults);
+            return apply_rule(RuleSet::conway());
+        }
+
+        [[nodiscard]] bool apply_preset_rule(std::size_t preset_index) {
+            if (preset_index >= kPopularRulePresets.size()) {
+                return false;
+            }
+            return apply_rule(kPopularRulePresets[preset_index].rules);
         }
 
         void update_panel_layout() {
             const int panel_width = std::min(kRulesPanelPreferredWidth, std::max(0, _window_width - 1));
             const int workspace_width = std::max(1, _window_width - panel_width);
             _panel_rect = {workspace_width, 0, panel_width, _window_height};
+            _preset_button_rects.fill(Rect{});
 
             if (_panel_rect.width <= 0) {
                 _birth_field_rect = {};
@@ -1891,6 +1917,30 @@ namespace {
             _apply_button_rect = {inner_x, y, inner_width, kRulesButtonHeight};
             y = _apply_button_rect.y + _apply_button_rect.height + kRulesPanelSectionGap;
             _reset_button_rect = {inner_x, y, inner_width, kRulesButtonHeight};
+            y = _reset_button_rect.y + _reset_button_rect.height + kRulesPanelSectionGap + 18;
+
+            const int left_button_width = std::max(1, (inner_width - kRulesPresetButtonGap) / 2);
+            const int right_button_x = inner_x + left_button_width + kRulesPresetButtonGap;
+            const int right_button_width = std::max(1, inner_width - left_button_width - kRulesPresetButtonGap);
+            for (std::size_t preset_index = 0; preset_index < kPopularRulePresets.size(); ++preset_index) {
+                const int row = static_cast<int>(preset_index / 2U);
+                const int button_y = y + row * (kRulesButtonHeight + kRulesPanelSectionGap);
+                const bool odd_last_button =
+                        ((kPopularRulePresets.size() % 2U) != 0U) &&
+                        (preset_index + 1U == kPopularRulePresets.size());
+                if (odd_last_button) {
+                    _preset_button_rects[preset_index] = {inner_x, button_y, inner_width, kRulesButtonHeight};
+                    continue;
+                }
+
+                const bool left_column = (preset_index % 2U) == 0U;
+                _preset_button_rects[preset_index] = {
+                        left_column ? inner_x : right_button_x,
+                        button_y,
+                        left_column ? left_button_width : right_button_width,
+                        kRulesButtonHeight,
+                };
+            }
         }
 
         void draw_text(int x, int baseline_y, std::string_view text) {
@@ -1996,6 +2046,12 @@ namespace {
 
             draw_button(_apply_button_rect, "Apply");
             draw_button(_reset_button_rect, "Reset To Default");
+            if (_preset_button_rects.front().width > 0) {
+                draw_text(text_x, _preset_button_rects.front().y - 6, "Popular presets");
+                for (std::size_t preset_index = 0; preset_index < kPopularRulePresets.size(); ++preset_index) {
+                    draw_button(_preset_button_rects[preset_index], kPopularRulePresets[preset_index].label);
+                }
+            }
         }
 
         void update_layout() {
@@ -2250,6 +2306,12 @@ namespace {
                             (void) set_focus(FocusField::Inactive);
                             return reset_to_default_rules();
                         }
+                        for (std::size_t preset_index = 0; preset_index < _preset_button_rects.size(); ++preset_index) {
+                            if (_preset_button_rects[preset_index].contains(event.x, event.y)) {
+                                (void) set_focus(FocusField::Inactive);
+                                return apply_preset_rule(preset_index);
+                            }
+                        }
                         return set_focus(FocusField::Inactive);
                     }
                     if (_horizontal_thumb_rect.contains(event.x, event.y)) {
@@ -2350,6 +2412,7 @@ namespace {
         Rect _survival_field_rect{};
         Rect _apply_button_rect{};
         Rect _reset_button_rect{};
+        std::array<Rect, kPopularRulePresets.size()> _preset_button_rects{};
         int _pitch_bytes = 0;
         int _image_width = 0;
         int _image_height = 0;

--- a/clife_tests.cpp
+++ b/clife_tests.cpp
@@ -248,6 +248,7 @@ namespace {
     void run_rule_change_case(const LifeBoard::CellBuffer &initial, int width, int height, LifeBoard::Backend requested_backend) {
         const LifeBoard::RuleSet conway = LifeBoard::RuleSet::conway();
         const LifeBoard::RuleSet highlife = LifeBoard::RuleSet::from_digit_strings("36", "23");
+        const LifeBoard::RuleSet day_night = LifeBoard::RuleSet::from_digit_strings("3678", "34678");
         LifeBoard board(initial, 4, width, height, requested_backend, conway);
         require(board.backend() == LifeBoard::Backend::BitPacked,
                 std::string(backend_name(requested_backend)) + " runtime rule-change backend mismatch");
@@ -269,6 +270,12 @@ namespace {
         board.advance();
         require(board.rules() == seeds.normalized(), "runtime rule-change seeds rules mismatch");
         require_equal(normalize_view(board.iterate()), after_seeds, "runtime rule-change seeds step mismatch");
+
+        board.set_rules(day_night);
+        const auto after_day_night = step_reference(after_seeds, width, height, day_night);
+        board.advance();
+        require(board.rules() == day_night.normalized(), "runtime rule-change day-and-night rules mismatch");
+        require_equal(normalize_view(board.iterate()), after_day_night, "runtime rule-change day-and-night step mismatch");
     }
 }
 
@@ -276,6 +283,9 @@ int main() {
     try {
         const LifeBoard::RuleSet conway = LifeBoard::RuleSet::conway();
         const LifeBoard::RuleSet highlife = LifeBoard::RuleSet::from_digit_strings("36", "23");
+        const LifeBoard::RuleSet twox2 = LifeBoard::RuleSet::from_digit_strings("36", "125");
+        const LifeBoard::RuleSet day_night = LifeBoard::RuleSet::from_digit_strings("3678", "34678");
+        const LifeBoard::RuleSet morley = LifeBoard::RuleSet::from_digit_strings("368", "245");
         const LifeBoard::RuleSet seeds = LifeBoard::RuleSet::from_digit_strings("2", "");
         const std::vector<std::pair<int, int>> dimensions = {
                 {1, 1},
@@ -319,9 +329,15 @@ int main() {
         }
 
         const auto highlife_case = make_case_cells(17, 19, 11, 0.32F);
+        const auto twox2_case = make_case_cells(17, 19, 13, 0.28F);
+        const auto day_night_case = make_case_cells(17, 19, 19, 0.44F);
+        const auto morley_case = make_case_cells(17, 19, 23, 0.26F);
         const auto seeds_case = make_case_cells(17, 19, 17, 0.18F);
         for (LifeBoard::Backend requested_backend: backend_requests) {
             run_backend_case(highlife_case, 17, 19, requested_backend, highlife);
+            run_backend_case(twox2_case, 17, 19, requested_backend, twox2);
+            run_backend_case(day_night_case, 17, 19, requested_backend, day_night);
+            run_backend_case(morley_case, 17, 19, requested_backend, morley);
             run_backend_case(seeds_case, 17, 19, requested_backend, seeds);
         }
 


### PR DESCRIPTION
## What was changed
- added preset buttons in the X11 rules panel for HighLife, 2x2, Day & Night, Morley, and Seeds
- wired preset clicks to update the Birth/Survival inputs and queue the selected rule immediately
- extended correctness coverage to the surfaced preset rules and documented the new UI in README.md

## Why it was changed
- the app already supports generic Life-like B/S rules, but switching to popular variants required manual entry
- preset buttons make the most commonly cited Life-like variants easier to explore directly from the UI

## Validation performed
- cmake -B./cmake-build-release -H. -DCMAKE_BUILD_TYPE=Release
- cmake --build ./cmake-build-release
- ctest --test-dir ./cmake-build-release --output-on-failure

## Known limitations or follow-up work
- preset popularity is an informed selection based on common Life-like rule references rather than telemetry from this app
- the preset buttons are not covered by an automated UI interaction test because the project test suite is backend-focused